### PR TITLE
Do JSON parsing post request

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -4,13 +4,6 @@ const Promise = require('bluebird');
 const Request = Promise.promisifyAll(require('request'));
 const compose = require('koa-compose');
 
-function buildResponseError(url, res) {
-  const error = new Error(`Received HTTP code ${res.statusCode} for GET ${url}`);
-  error.statusCode = res.statusCode;
-  error.headers = res.headers;
-  return error;
-}
-
 class Blackadder {
   constructor() {
     this._url = undefined;
@@ -50,28 +43,33 @@ class Blackadder {
     return this;
   }
 
-  _applyPlugins(res) {
+  _applyPlugins(ctx, next) {
     // let i = this._plugins.length;
     // while (i--) {
     //   res = this._plugins[i].call(null, res);
     // }
     // return res;
-    const ctx = {};
-    ctx.res = res;
     const fn = compose(this._plugins);
-    return fn(ctx);
+    return fn(ctx, next);
+  }
+
+  _makeRequest() {
+    const context = {};
+
+    return this._applyPlugins(context, (ctx, next) => {
+      return this._execute().then((res) => {
+        ctx.res = res;
+        return next();
+      });
+    }).then(() => {
+      return context;
+    });
   }
 
   asBody() {
-    return this._execute()
-      .then((res) => {
-        if (res.statusCode != 200) {
-          throw buildResponseError(this._url, res);
-        }
-        return this._applyPlugins(res)
-          .then((ctx) => {
-            return res.body;
-          });
+    return this._makeRequest()
+      .then((ctx) => {
+        return ctx.res.body;
       });
   }
 }

--- a/lib/plugins/asJson.js
+++ b/lib/plugins/asJson.js
@@ -1,5 +1,7 @@
 module.exports = () => {
   return (ctx, next) => {
-    ctx.res.body = JSON.parse(ctx.res.body);
+    return next().then(() => {
+      ctx.res.body = JSON.parse(ctx.res.body);
+    });
   };
 };


### PR DESCRIPTION
I think this should make the plugins occur before and after the request, this allows you to create plugins such as the cache plugin (thinking about next) which never called `next()` and thus never execute():

```
function (ctx, next) {
  if (inCache(ctx.req)) {
   ctx.res = getFromCache(ctx.req);
  } else {
   return next();
  }
}
```

Also, removed `buildResponseError` and all tests passed?